### PR TITLE
Auto positioning for dropdown menus

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -275,6 +275,14 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
         scrollbarPadding,
         scrollbarWidth = 0;
 
+      if (self.dropdownMenu.hasClass('dropdown-menu-auto')) {
+        self.dropdownMenu.css({
+          display: isOpen ? 'block' : 'none',
+          right: 'auto'
+        });
+        pos = $position.positionElements($element, self.dropdownMenu, 'auto bottom-left', true);
+      }
+      
       css = {
         top: pos.top + 'px',
         display: isOpen ? 'block' : 'none'


### PR DESCRIPTION
Add .dropdown-menu-auto to a uib-dropdown-menu to automatic align the dropdown menu.

This is a dirty hack, but it doesn't change anything in the the current logic. Only tested along with dropdown-append-to-body